### PR TITLE
Defered close to prepared statement object

### DIFF
--- a/oci8.go
+++ b/oci8.go
@@ -533,6 +533,7 @@ func (c *OCI8Conn) Exec(query string, args []driver.Value) (driver.Result, error
 
 func (c *OCI8Conn) exec(ctx context.Context, query string, args []namedValue) (driver.Result, error) {
 	s, err := c.prepare(ctx, query)
+	defer s.Close()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When using db.Exec numerous time in the same program execution, after approx 300 (on vagrant VM with Oracle installed) runs of db.Exec the "ORA-01000: maximum open cursors exceeded" error is thrown. 